### PR TITLE
Add Qualification GHA

### DIFF
--- a/.github/workflows/qualification-report.yaml
+++ b/.github/workflows/qualification-report.yaml
@@ -1,7 +1,7 @@
 on:
   release:
     types: [published]
-  pull-request:
+  pull_request:
     branches: main
   workflow_dispatch:
 

--- a/.github/workflows/qualification-report.yaml
+++ b/.github/workflows/qualification-report.yaml
@@ -1,0 +1,34 @@
+on:
+  release:
+    types: [published]
+  pull-request:
+    branches: main
+  workflow_dispatch:
+
+name: qualification-report
+
+jobs:
+  qualification-report:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.1.3'
+          use-public-rspm: true
+
+      - name: qualification report trigger
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: Gilead-BioStats/gsm.qc
+          event-type: qualification
+          client-payload: '{
+          "GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+          "repository": "${{ github.repository }}",
+          "release_tag": "${{ github.ref_name }}"
+          }'


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Add GHA that triggers qualification-report-dispatch workflow in gsm.qc and returns report to gsm.reporting.

Note- this action requires an update to the Organization GH Token, which will occur prior to release.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #39

