### PR TITLE
Fix #50- update endpoint column names to align with raw+

### DIFF
--- a/inst/workflow/1_mappings/AntiCancer.yaml
+++ b/inst/workflow/1_mappings/AntiCancer.yaml
@@ -6,21 +6,17 @@ meta:
 spec:
   Raw_AntiCancer:
     subjid:
-      source_col: SUBJID
       type: character
-    act_treatment:
-      source_col: cmtrt
+    cmtrt:
       type: character
-    act_date:
-      source_col: cmst_dt
+    cmst_dt:
       type: Date
-
 steps:
   - name: gsm.core::RunQuery
     output: Mapped_AntiCancer
     params:
       df: Raw_AntiCancer
-      strQuery: "SELECT subjid, ANY_VALUE(act_treatment) as act_treatment, MIN(act_date) AS act_date FROM df
-                WHERE act_treatment != ''
+      strQuery: "SELECT subjid, ANY_VALUE(cmtrt) as cmtrt, MIN(cmst_dt) AS cmst_dt FROM df
+                WHERE cmtrt != ''
                 GROUP BY subjid"
 

--- a/inst/workflow/1_mappings/AntiCancer.yaml
+++ b/inst/workflow/1_mappings/AntiCancer.yaml
@@ -9,10 +9,10 @@ spec:
       source_col: SUBJID
       type: character
     act_treatment:
-      source_col: CMTRT
+      source_col: cmtrt
       type: character
     act_date:
-      source_col: CMSTDAT
+      source_col: cmst_dt
       type: Date
 
 steps:

--- a/inst/workflow/1_mappings/Baseline.yaml
+++ b/inst/workflow/1_mappings/Baseline.yaml
@@ -9,7 +9,7 @@ spec:
       source_col: SUBJID
       type: character
     baseline_scan_date:
-      source_col: SCANDAT
+      source_col: scan_dt
       type: Date
 steps:
   - name: gsm.core::RunQuery

--- a/inst/workflow/1_mappings/Baseline.yaml
+++ b/inst/workflow/1_mappings/Baseline.yaml
@@ -6,15 +6,13 @@ meta:
 spec:
   Raw_Baseline:
     subjid:
-      source_col: SUBJID
       type: character
-    baseline_scan_date:
-      source_col: scan_dt
+    scan_dt:
       type: Date
 steps:
   - name: gsm.core::RunQuery
     output: Mapped_Baseline
     params:
       df: Raw_Baseline
-      strQuery: "SELECT subjid, baseline_scan_date FROM df
+      strQuery: "SELECT subjid, scan_dt FROM df
                 WHERE subjid IS NOT NULL"

--- a/inst/workflow/1_mappings/Consents.yaml
+++ b/inst/workflow/1_mappings/Consents.yaml
@@ -9,13 +9,11 @@ spec:
       source_col: SUBJID
       type: character
     consdat:
-      source_col: CONSDAT
+      source_col: cons_dt
       type: Date
     constype:
-      source_col: CONSTYPE
       type: character
     conscat:
-      source_col: CONSCAT
       type: character
 
 steps:

--- a/inst/workflow/1_mappings/Consents.yaml
+++ b/inst/workflow/1_mappings/Consents.yaml
@@ -6,10 +6,8 @@ meta:
 spec:
   Raw_Consents:
     subjid:
-      source_col: SUBJID
       type: character
-    consdat:
-      source_col: cons_dt
+    cons_dt:
       type: Date
     constype:
       type: character
@@ -21,11 +19,11 @@ steps:
     output: Temp_Consents
     params:
       df: Raw_Consents
-      strQuery: "SELECT subjid, consdat, constype, conscat FROM df
+      strQuery: "SELECT subjid, cons_dt, constype, conscat FROM df
                 WHERE constype = 'WITHDRAWAL OF CONSENT' AND conscat = 'STUDY CONSENT'"
   - name: gsm.endpoints::complete_consents
     output: Mapped_Consents
     params:
       dfConsents: Temp_Consents
-      dfStudyCompletion: Mapped_StudyCompletion
+      dfStudyCompletion: Mapped_STUDCOMP
 

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -6,22 +6,20 @@ meta:
 spec:
   Raw_Death:
     subjid:
-      source_col: SUBJID
       type: character
-    death_date:
-      source_col: death_dt
+    death_dt:
       type: Date
 steps:
   - name: gsm.core::RunQuery
     output: Temp_Death
     params:
       df: Raw_Death
-      strQuery: "SELECT subjid, death_date FROM df
-                WHERE subjid IS NOT NULL AND death_date IS NOT NULL"
+      strQuery: "SELECT subjid, death_dt FROM df
+                WHERE subjid IS NOT NULL AND death_dt IS NOT NULL"
   - name: gsm.endpoints::complete_death
     output: Mapped_Death
     params:
       dfDeath: Temp_Death
-      dfStudyCompletion: Mapped_StudyCompletion
+      dfStudyCompletion: Mapped_STUDCOMP
       dfOverallResponse: Mapped_OverallResponse
 

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -9,7 +9,7 @@ spec:
       source_col: SUBJID
       type: character
     death_date:
-      source_col: DEATHDAT
+      source_col: death_dt
       type: Date
 steps:
   - name: gsm.core::RunQuery

--- a/inst/workflow/1_mappings/OverallResponse.yaml
+++ b/inst/workflow/1_mappings/OverallResponse.yaml
@@ -6,21 +6,17 @@ meta:
 spec:
   Raw_OverallResponse:
     subjid:
-      source_col: SUBJID
       type: character
-    response_folder:
-      source_col: FOLDERNAME
+    foldername:
       type: character
-    response:
-      source_col: ovrlesp
+    ovrlesp:
       type: character
-    response_date:
-      source_col: rs_dt
+    rs_dt:
       type: Date
 steps:
   - name: gsm.core::RunQuery
     output: Mapped_OverallResponse
     params:
       df: Raw_OverallResponse
-      strQuery: "SELECT subjid, response_folder, response, response_date FROM df
+      strQuery: "SELECT subjid, foldername, ovrlesp, rs_dt FROM df
                 WHERE subjid IS NOT NULL"

--- a/inst/workflow/1_mappings/OverallResponse.yaml
+++ b/inst/workflow/1_mappings/OverallResponse.yaml
@@ -7,7 +7,8 @@ spec:
   Raw_OverallResponse:
     subjid:
       type: character
-    foldername:
+    response_folder:
+      source_col: foldername
       type: character
     ovrlesp:
       type: character
@@ -18,5 +19,5 @@ steps:
     output: Mapped_OverallResponse
     params:
       df: Raw_OverallResponse
-      strQuery: "SELECT subjid, foldername, ovrlesp, rs_dt FROM df
+      strQuery: "SELECT subjid, response_folder, ovrlesp, rs_dt FROM df
                 WHERE subjid IS NOT NULL"

--- a/inst/workflow/1_mappings/OverallResponse.yaml
+++ b/inst/workflow/1_mappings/OverallResponse.yaml
@@ -12,10 +12,10 @@ spec:
       source_col: FOLDERNAME
       type: character
     response:
-      source_col: OVRLRESP_STD
+      source_col: ovrlesp
       type: character
     response_date:
-      source_col: RSDAT
+      source_col: rs_dt
       type: Date
 steps:
   - name: gsm.core::RunQuery

--- a/inst/workflow/1_mappings/Randomization.yaml
+++ b/inst/workflow/1_mappings/Randomization.yaml
@@ -6,27 +6,21 @@ meta:
 spec:
   Raw_Randomization:
     studyid:
-      source_col: STUDYID
       type: character
     invid:
-      source_col: INVID
       type: character
     subjid:
-      source_col: SUBJID
       type: character
-    randomization_date:
-      source_col: RGMN_DT
+    rgmn_dt:
       type: Date
     status:
-      source_col: STATUS
       type: character
     country:
-      source_col: COUNTRY
       type: character
 steps:
   - name: gsm.core::RunQuery
     output: Mapped_Randomization
     params:
       df: Raw_Randomization
-      strQuery: "SELECT  studyid, invid, subjid, randomization_date, status, country FROM df
+      strQuery: "SELECT  studyid, invid, subjid, rgmn_dt, status, country FROM df
                 WHERE subjid IS NOT NULL AND (status != 'Screen Failed' OR status IS NULL)"

--- a/inst/workflow/1_mappings/Randomization.yaml
+++ b/inst/workflow/1_mappings/Randomization.yaml
@@ -15,7 +15,7 @@ spec:
       source_col: SUBJID
       type: character
     randomization_date:
-      source_col: RGMNDTN
+      source_col: RGMN_DT
       type: Date
     status:
       source_col: STATUS

--- a/inst/workflow/1_mappings/Visit.yaml
+++ b/inst/workflow/1_mappings/Visit.yaml
@@ -7,11 +7,9 @@ spec:
   Raw_VISIT:
     subjid:
       type: character
-    visit_date:
-      source_col: visit_dt
+    visit_dt:
       type: character
-    visit:
-      source_col: foldername
+    foldername:
       type: character
     invid:
       type: character
@@ -20,6 +18,6 @@ steps:
     name: gsm.core::RunQuery
     params:
       df: Raw_VISIT
-      strQuery: "SELECT subjid, visit_date, visit, invid FROM df"
+      strQuery: "SELECT subjid, visit_dt, foldername, invid FROM df"
 
 

--- a/inst/workflow/1_mappings/Visit.yaml
+++ b/inst/workflow/1_mappings/Visit.yaml
@@ -15,7 +15,6 @@ spec:
       type: character
     invid:
       type: character
-
 steps:
   - output: Mapped_VISIT
     name: gsm.core::RunQuery

--- a/inst/workflow/1_mappings/Visit.yaml
+++ b/inst/workflow/1_mappings/Visit.yaml
@@ -9,7 +9,8 @@ spec:
       type: character
     visit_dt:
       type: character
-    foldername:
+    visit_folder:
+      source_col: foldername
       type: character
     invid:
       type: character
@@ -18,6 +19,6 @@ steps:
     name: gsm.core::RunQuery
     params:
       df: Raw_VISIT
-      strQuery: "SELECT subjid, visit_dt, foldername, invid FROM df"
+      strQuery: "SELECT subjid, visit_dt, visit_folder, invid FROM df"
 
 


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Align endpoints domains to raw+ outputs. Only acceptions are `foldername` in OverallResponse and Visit needed to be renamed to include more domain information so that there aren't duplicate column names that aren't identical.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #50

