### PR TITLE
Remove extraneous column lists in `RunQuery` steps.

### DIFF
--- a/inst/workflow/1_mappings/VISIT.yaml
+++ b/inst/workflow/1_mappings/VISIT.yaml
@@ -18,9 +18,7 @@ spec:
       type: character
 steps:
   - output: Mapped_VISIT
-    name: gsm.core::RunQuery
+    name: =
     params:
-      df: Raw_VISIT
-      strQuery: "SELECT studyid, subjid, visit_dt, visit, invid FROM df"
-
-
+      lhs: Mapped_VISIT
+      rhs: Raw_VISIT


### PR DESCRIPTION
## Overview
Removes duplicate column list. Need to review the rest of the mappings.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
- Partially closes #52 