### PR TITLE
Closes #91 initial `db_lock_dt` implementation

### DIFF
--- a/inst/workflow/1_mappings/STUDY.yaml
+++ b/inst/workflow/1_mappings/STUDY.yaml
@@ -26,6 +26,8 @@ spec:
       type: Date
     est_lpfv:
       type: Date
+    db_lock_dt:
+      type: Date
     therapeutic_area:
       type: character
     protocol_indication:


### PR DESCRIPTION
## Overview
New field `db_lock_dt` is already integrated to the data lake, we should add this to the spec for `STUDY.yaml`

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #91 

