### PR TITLE
Update `Death.yaml`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     tidyr,
     yaml
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@main
+    gsm.core=Gilead-BioStats/gsm.core@fix-130
 Suggests:
     DT,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     tidyr,
     yaml
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@fix-130
+    gsm.core=Gilead-BioStats/gsm.core@dev
 Suggests:
     DT,
     knitr,

--- a/R/complete_death.R
+++ b/R/complete_death.R
@@ -84,7 +84,7 @@ complete_death <- function(
     "studyid",
     "subjid",
     "death_dt",
-    chrDeathDayCol,
+    "death_dy",
     "death",
     "pd_date"
   )

--- a/R/complete_death.R
+++ b/R/complete_death.R
@@ -48,7 +48,6 @@ complete_death <- function(
   dfOverallResponse,
   dfRandomization,
   chrDeathDateCol = "death_dt",
-  chrDeathDayCol = "death_dy",
   chrStudyDiscontinuationReasonCol = "compreas",
   chrDeathResponse = "Death",
   chrResponseCol = "ovrlresp",

--- a/R/complete_death.R
+++ b/R/complete_death.R
@@ -83,7 +83,7 @@ complete_death <- function(
   select_cols <- c(
     "studyid",
     "subjid",
-    chrDeathDateCol,
+    "death_dt",
     chrDeathDayCol,
     "death",
     "pd_date"

--- a/R/complete_death.R
+++ b/R/complete_death.R
@@ -1,0 +1,123 @@
+#' combines study completion data, overall response data, and death data to output a dataframe containing pd date and death status.
+#'
+#' @param dfDeath `data.frame` death data frame with mapped names
+#' @param dfStudyCompletion `data.frame` study completion data frame with mapped names
+#' @param dfOverallResponse `data.frame` overall response data frame with mapped names
+#' @param chrDeathDateCol `character` name of column in `dfDeath` that contains
+#'   the death date. Default: `"death_dt"`.
+#' @param chrStudyDiscontinuationReasonCol `character` name of column in `dfStudyCompletion` that contains
+#'   the reason for study completion. Default: `"compreas"`.
+#' @param chrDeathResponse `character` value of `compreas` in `dfStudyCompletion` that indicates death. Default is "Death"
+#' @param chrResponseCol `character` name of column in `dfOverallResponse` that contains
+#'   the overall response. Default: `"ovrlresp"`.
+#' @param chrPDResponse `character` value of `ovrlresp` in `dfOverallResponse` that indicates PD. Default is "PD"
+#' @param chrResponseDateCol `character` name of column in `dfOverallResponse` that contains
+#'   the overall response date. Default: `"rs_dt"`.
+#'
+#' @return a `data.frame` combining death status and first PD status
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' lSource <- list(
+#'   Source_OverallResponse = gsm.endpoints::lSource_ep$Raw_OverallResponse, ## Overall response
+#'   Source_Death = gsm.endpoints::lSource_ep$Raw_Death, ## Death date
+#'   Source_STUDCOMP = gsm.endpoints::lSource_ep$Raw_STUDCOMP
+#' )
+#'
+#' lMapping <- gsm.core::MakeWorkflowList(
+#'   strPath = "workflow/1_mappings",
+#'   strNames = c("Death", "OverallResponse", "STUDCOMP"),
+#'   strPackage = "gsm.mapping"
+#' )
+#'
+#' combined_spec <- gsm.mapping::CombineSpecs(lMapping)
+#'
+#' lRaw <- gsm.mapping::Ingest(lSourceData = lSource, lSpec = combined_spec)
+#'
+#' complete_death(
+#'   dfDeath = lRaw$Raw_Death,
+#'   dfStudyCompletion = lRaw$Raw_STUDCOMP,
+#'   dfOverallResponse = lRaw$Raw_OverallResponse
+#' )
+#' }
+#'
+complete_death <- function(
+  dfDeath,
+  dfStudyCompletion,
+  dfOverallResponse,
+  dfRandomization,
+  chrDeathDateCol = "death_dt",
+  chrDeathDayCol = "death_dy",
+  chrStudyDiscontinuationReasonCol = "compreas",
+  chrDeathResponse = "Death",
+  chrResponseCol = "ovrlresp",
+  chrPDResponse = "PD",
+  chrResponseDateCol = "rs_dt",
+  chrRandomizationDateCol = "rgmn_dt"
+) {
+  death <- dfStudyCompletion %>%
+    filter(
+      .data[[ chrStudyDiscontinuationReasonCol ]] == chrDeathResponse
+    ) %>%
+    full_join(dfDeath) %>%
+    left_join(dfRandomization, by = c("studyid", "subjid")) %>%
+    mutate(
+      death_dt = .data[[ chrDeathDateCol ]],
+      death_dy = as.numeric(.data[[ chrDeathDateCol ]] - .data[[ chrRandomizationDateCol ]]),
+      death = TRUE
+    )
+
+  pd <- dfOverallResponse %>%
+    filter(
+      .data[[ chrResponseCol ]] == chrPDResponse,
+      !is.na(.data[[ chrResponseDateCol ]])
+    ) %>%
+    group_by(.data$subjid) %>%
+    slice(which.min(.data[[ chrResponseDateCol ]])) %>%
+    ungroup() %>%
+    mutate(
+      pd_date = .data[[ chrResponseDateCol ]]
+    )
+
+  select_cols <- c(
+    "studyid",
+    "subjid",
+    chrDeathDateCol,
+    chrDeathDayCol,
+    "death",
+    "pd_date"
+  )
+
+  output <- death %>%
+    full_join(
+      pd,
+      c("studyid", "subjid")
+    ) %>%
+    select(
+      all_of(
+        select_cols
+      )
+    )
+
+  # Warn if death date is missing for any patients marked as deceased.
+  missing_death_dates <- output %>%
+    filter(
+      .data$death,
+      is.na(.data$death_dt)
+    ) %>%
+    pull(.data$subjid)
+
+  if (length(missing_death_dates) > 1) {
+    cli::cli_alert_warning(
+      glue::glue(
+        "Death date missing for patients: {
+           stringr::str_wrap(stringr::str_flatten(missing_death_dates, collapse = ', '), 48)
+        }\nLast known date will be used as a substitute."
+      )
+    )
+  }
+
+  return(output)
+}
+

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -43,59 +43,16 @@ spec:
     rgmn_dt:
       type: Date
 steps:
-  - name: dplyr::left_join
-    output: Raw_Death_Rand
-    params:
-      x: Raw_Death
-      "y": Mapped_Randomization
-      by:
-        - studyid
-        - subjid
   - name: gsm.core::RunQuery
     output: Temp_Death
     params:
-      df: Raw_Death_Rand
-      strQuery: "SELECT studyid, subjid, death_dt, DATEDIFF('day', rgmn_dt, death_dt) as death_dy
-                FROM df
+      df: Raw_Death
+      strQuery: "SELECT studyid, subjid, death_dt FROM df
                 WHERE subjid IS NOT NULL AND death_dt IS NOT NULL"
-  - name: gsm.core::RunQuery
-    output: Temp_Death_Filtered
-    params:
-      df: Mapped_STUDCOMP
-      strQuery: "SELECT studyid, invid, subjid, compyn, mincreated_dts
-                FROM df
-                WHERE compreas = 'Death'"
-  - name: dplyr::full_join
-    output: Death_Joined
-    params:
-      x: Temp_Death_Filtered
-      "y": Temp_Death
-      by:
-        - studyid
-        - subjid
-  - name: gsm.core::RunQuery
-    output: Death_Joined_Final
-    params:
-      df: Death_Joined
-      strQuery: "SELECT *, 1 as death
-                FROM df"
-  - name: gsm.core::RunQuery
-    output: PD_Filtered
-    params:
-      df: Mapped_OverallResponse
-      strQuery: "SELECT studyid, subjid, rs_dt AS pd_date
-                FROM (
-                  SELECT *, ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY rs_dt) as rn
-                  FROM df
-                  WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL
-                )
-                WHERE rn = 1"
-  - name: dplyr::full_join
+  - name: gsm.endpoints::complete_death
     output: Mapped_Death
     params:
-      x: Death_Joined_Final
-      "y": PD_Filtered
-      by:
-        - studyid
-        - subjid
-
+      dfDeath: Temp_Death
+      dfStudyCompletion: Mapped_STUDCOMP
+      dfOverallResponse: Mapped_OverallResponse
+      dfRandomization: Mapped_Randomization

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -33,7 +33,8 @@ spec:
       type: character
     ovrlresp:
       type: character
-    rs_dt:
+    pd_date:
+      source_col: rs_dt
       type: Date
   Mapped_Randomization:
     studyid:
@@ -55,25 +56,21 @@ steps:
     output: Temp_Death
     params:
       df: Raw_Death_Rand
-      strQuery: "SELECT *, DATEDIFF('day', rgmn_dt, death_dt) as death_days FROM df"
-  - name: gsm.core::RunQuery
-    output: Temp_Death2
-    params:
-      df: Temp_Death
-      strQuery: "SELECT studyid, subjid, death_dt, death_days FROM df
+      strQuery: "SELECT studyid, subjid, death_dt, DATEDIFF('day', rgmn_dt, death_dt) as death_dy
+                FROM df
                 WHERE subjid IS NOT NULL AND death_dt IS NOT NULL"
   - name: gsm.core::RunQuery
     output: Temp_Death_Filtered
     params:
       df: Mapped_STUDCOMP
-      strQuery: "SELECT *
+      strQuery: "SELECT studyid, invid, subjid, compyn, mincreated_dts
                 FROM df
                 WHERE compreas = 'Death'"
   - name: dplyr::full_join
     output: Death_Joined
     params:
       x: Temp_Death_Filtered
-      "y": Temp_Death2
+      "y": Temp_Death
       by:
         - studyid
         - subjid
@@ -81,24 +78,18 @@ steps:
     output: Death_Joined_Final
     params:
       df: Death_Joined
-      strQuery: "SELECT *,
-                        death = 1,
-                        death_days
+      strQuery: "SELECT *, 1 as death
                 FROM df"
-  - name: gsm.core::RunQuery
-    output: PD_Data
-    params:
-      df: Mapped_OverallResponse
-      strQuery: "SELECT *,
-                        ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY rs_dt) as rn
-                FROM df
-                WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL AND rn = 1"
   - name: gsm.core::RunQuery
     output: PD_Filtered
     params:
-      df: PD_Data
+      df: Mapped_OverallResponse
       strQuery: "SELECT studyid, subjid, pd_date
-                FROM df
+                FROM (
+                  SELECT *, ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY pd_date) as rn
+                  FROM df
+                  WHERE ovrlresp = 'PD' AND pd_date IS NOT NULL
+                )
                 WHERE rn = 1"
   - name: dplyr::full_join
     output: Mapped_Death

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -36,17 +36,76 @@ spec:
       type: character
     rs_dt:
       type: Date
+  Mapped_Randomization:
+    subjid:
+      type: character
+    rgmn_dt:
+      type: Date
 steps:
+  - name: dplyr::left_join
+    output: Raw_Death_Rand
+    params:
+      params:
+      x: Raw_Death
+      "y": Mapped_Randomization
+      by:
+        - subjid
   - name: gsm.core::RunQuery
     output: Temp_Death
     params:
-      df: Raw_Death
-      strQuery: "SELECT studyid, subjid, death_dt FROM df
+      df: Raw_Death_Rand
+      strQuery: "SELECT *, DATEDIFF('day', rgmn_dt, death_dt) as death_days FROM df
+                 WHERE death_dt IS NOT NULL AND DATEDIFF('day', rgmn_dt, death_dt) <= 90"
+  - name: gsm.core::RunQuery
+    output: Temp_Death2
+    params:
+      df: Temp_Death
+      strQuery: "SELECT studyid, subjid, death_dt, death_days FROM df
                 WHERE subjid IS NOT NULL AND death_dt IS NOT NULL"
-  - name: gsm.endpoints::complete_death
+  - name: gsm.core::RunQuery
+    output: Temp_Death_Filtered
+    params:
+      df: Mapped_STUDCOMP
+      strQuery: "SELECT studyid, subjid, compreas
+                FROM df
+                WHERE compreas = 'DEATH'"
+  - name: gsm.core::RunQuery
+    output: Death_Joined
+    params:
+      df: Temp_Death_Filtered
+      df2: Temp_Death2
+      strQuery: "SELECT COALESCE(df.studyid, df2.studyid) as studyid,
+                        COALESCE(df.subjid, df2.subjid) as subjid,
+                        df2.death_dt,
+                        CASE WHEN df2.death_dt IS NOT NULL THEN 1 ELSE 0 END as death
+                FROM df
+                FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"
+  - name: gsm.core::RunQuery
+    output: PD_Data
+    params:
+      df: Mapped_OverallResponse
+      strQuery: "SELECT studyid, subjid, rs_dt as pd_date,
+                        ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY rs_dt) as rn
+                FROM df
+                WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL"
+  - name: gsm.core::RunQuery
+    output: PD_Filtered
+    params:
+      df: PD_Data
+      strQuery: "SELECT studyid, subjid, pd_date
+                FROM df
+                WHERE rn = 1"
+  - name: gsm.core::RunQuery
     output: Mapped_Death
     params:
-      dfDeath: Temp_Death
-      dfStudyCompletion: Mapped_STUDCOMP
-      dfOverallResponse: Mapped_OverallResponse
+      df: Death_Joined
+      df2: PD_Filtered
+      strQuery: "SELECT COALESCE(df.studyid, df2.studyid) as studyid,
+                        COALESCE(df.subjid, df2.subjid) as subjid,
+                        df.death_dt,
+                        df.death,
+                        df.death_day,
+                        df2.pd_date
+                FROM df
+                FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"
 

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -30,7 +30,6 @@ spec:
     subjid:
       type: character
     response_folder:
-      source_col: foldername
       type: character
     ovrlresp:
       type: character
@@ -70,18 +69,22 @@ steps:
       strQuery: "SELECT studyid, subjid, compreas
                 FROM df
                 WHERE compreas = 'DEATH'"
-  - name: gsm.core::RunQuery
+  - name: dplyr::full_join
     output: Death_Joined
     params:
-      df: Temp_Death_Filtered
-      df2: Temp_Death2
-      strQuery: "SELECT COALESCE(df.studyid, df2.studyid) as studyid,
-                        COALESCE(df.subjid, df2.subjid) as subjid,
-                        df2.death_dt,
-                        CASE WHEN df2.death_dt IS NOT NULL THEN 1 ELSE 0 END as death,
-                        df2.death_days
-                FROM df
-                FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"
+      x: Temp_Death_Filtered
+      "y": Temp_Death2
+      by:
+        - studyid
+        - subjid
+  - name: gsm.core::RunQuery
+    output: Death_Joined_Final
+    params:
+      df: Death_Joined
+      strQuery: "SELECT studyid, subjid, death_dt,
+                        CASE WHEN death_dt IS NOT NULL THEN 1 ELSE 0 END as death,
+                        death_days
+                FROM df"
   - name: gsm.core::RunQuery
     output: PD_Data
     params:
@@ -97,17 +100,12 @@ steps:
       strQuery: "SELECT studyid, subjid, pd_date
                 FROM df
                 WHERE rn = 1"
-  - name: gsm.core::RunQuery
+  - name: dplyr::full_join
     output: Mapped_Death
     params:
-      df: Death_Joined
-      df2: PD_Filtered
-      strQuery: "SELECT COALESCE(df.studyid, df2.studyid) as studyid,
-                        COALESCE(df.subjid, df2.subjid) as subjid,
-                        df.death_dt,
-                        df.death,
-                        df.death_days,
-                        df2.pd_date
-                FROM df
-                FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"
+      x: Death_Joined_Final
+      "y": PD_Filtered
+      by:
+        - studyid
+        - subjid
 

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -45,7 +45,6 @@ steps:
   - name: dplyr::left_join
     output: Raw_Death_Rand
     params:
-      params:
       x: Raw_Death
       "y": Mapped_Randomization
       by:

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -77,7 +77,8 @@ steps:
       strQuery: "SELECT COALESCE(df.studyid, df2.studyid) as studyid,
                         COALESCE(df.subjid, df2.subjid) as subjid,
                         df2.death_dt,
-                        CASE WHEN df2.death_dt IS NOT NULL THEN 1 ELSE 0 END as death
+                        CASE WHEN df2.death_dt IS NOT NULL THEN 1 ELSE 0 END as death,
+                        df2.death_days
                 FROM df
                 FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"
   - name: gsm.core::RunQuery
@@ -104,7 +105,7 @@ steps:
                         COALESCE(df.subjid, df2.subjid) as subjid,
                         df.death_dt,
                         df.death,
-                        df.death_day,
+                        df.death_days,
                         df2.pd_date
                 FROM df
                 FULL OUTER JOIN df2 ON df.studyid = df2.studyid AND df.subjid = df2.subjid"

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -33,8 +33,7 @@ spec:
       type: character
     ovrlresp:
       type: character
-    pd_date:
-      source_col: rs_dt
+    rs_dt:
       type: Date
   Mapped_Randomization:
     studyid:
@@ -84,11 +83,11 @@ steps:
     output: PD_Filtered
     params:
       df: Mapped_OverallResponse
-      strQuery: "SELECT studyid, subjid, pd_date
+      strQuery: "SELECT studyid, subjid, rs_dt AS pd_date
                 FROM (
-                  SELECT *, ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY pd_date) as rn
+                  SELECT *, ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY rs_dt) as rn
                   FROM df
-                  WHERE ovrlresp = 'PD' AND pd_date IS NOT NULL
+                  WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL
                 )
                 WHERE rn = 1"
   - name: dplyr::full_join

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -66,9 +66,9 @@ steps:
     output: Temp_Death_Filtered
     params:
       df: Mapped_STUDCOMP
-      strQuery: "SELECT studyid, subjid, compreas
+      strQuery: "SELECT *
                 FROM df
-                WHERE compreas = 'DEATH'"
+                WHERE compreas = 'Death'"
   - name: dplyr::full_join
     output: Death_Joined
     params:
@@ -81,18 +81,18 @@ steps:
     output: Death_Joined_Final
     params:
       df: Death_Joined
-      strQuery: "SELECT studyid, subjid, death_dt,
-                        CASE WHEN death_dt IS NOT NULL THEN 1 ELSE 0 END as death,
+      strQuery: "SELECT *,
+                        death = 1,
                         death_days
                 FROM df"
   - name: gsm.core::RunQuery
     output: PD_Data
     params:
       df: Mapped_OverallResponse
-      strQuery: "SELECT studyid, subjid, rs_dt as pd_date,
+      strQuery: "SELECT *,
                         ROW_NUMBER() OVER (PARTITION BY subjid ORDER BY rs_dt) as rn
                 FROM df
-                WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL"
+                WHERE ovrlresp = 'PD' AND rs_dt IS NOT NULL AND rn = 1"
   - name: gsm.core::RunQuery
     output: PD_Filtered
     params:

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -37,6 +37,8 @@ spec:
     rs_dt:
       type: Date
   Mapped_Randomization:
+    studyid:
+      type: character
     subjid:
       type: character
     rgmn_dt:
@@ -48,6 +50,7 @@ steps:
       x: Raw_Death
       "y": Mapped_Randomization
       by:
+        - studyid
         - subjid
   - name: gsm.core::RunQuery
     output: Temp_Death

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -54,8 +54,7 @@ steps:
     output: Temp_Death
     params:
       df: Raw_Death_Rand
-      strQuery: "SELECT *, DATEDIFF('day', rgmn_dt, death_dt) as death_days FROM df
-                 WHERE death_dt IS NOT NULL AND DATEDIFF('day', rgmn_dt, death_dt) <= 90"
+      strQuery: "SELECT *, DATEDIFF('day', rgmn_dt, death_dt) as death_days FROM df"
   - name: gsm.core::RunQuery
     output: Temp_Death2
     params:

--- a/inst/workflow/1_mappings/Death.yaml
+++ b/inst/workflow/1_mappings/Death.yaml
@@ -49,7 +49,7 @@ steps:
       df: Raw_Death
       strQuery: "SELECT studyid, subjid, death_dt FROM df
                 WHERE subjid IS NOT NULL AND death_dt IS NOT NULL"
-  - name: gsm.endpoints::complete_death
+  - name: gsm.mapping::complete_death
     output: Mapped_Death
     params:
       dfDeath: Temp_Death

--- a/tests/testthat/_snaps/complete_death.md
+++ b/tests/testthat/_snaps/complete_death.md
@@ -1,0 +1,35 @@
+# verify complete_death() output is valid for data.frame input (#47)
+
+    Code
+      test
+    Output
+                studyid subjid   death_dt death_dy death    pd_date
+      1  AA-AA-000-0000 S34463       <NA>       NA  TRUE       <NA>
+      2  AA-AA-000-0000 S95593 2012-01-02        1  TRUE       <NA>
+      3  AA-AA-000-0000 S49825 2012-01-21       20  TRUE       <NA>
+      4  AA-AA-000-0000 S43474 2012-01-13       12  TRUE       <NA>
+      5  AA-AA-000-0000 S51782 2012-02-01        0  TRUE       <NA>
+      6  AA-AA-000-0000 S47153 2012-02-04       34  TRUE       <NA>
+      7  AA-AA-000-0000 S74797 2012-02-01      -29  TRUE       <NA>
+      8  AA-AA-000-0000 S19838 2012-03-18       17  TRUE       <NA>
+      9  AA-AA-000-0000 S28760 2012-03-28       NA  TRUE       <NA>
+      10 AA-AA-000-0000 S50779 2012-03-25       84  TRUE       <NA>
+      11 AA-AA-000-0000 S39113 2012-03-13       41  TRUE       <NA>
+      12 AA-AA-000-0000 S62825 2012-03-08       36  TRUE       <NA>
+      13 AA-AA-000-0000 S87088 2012-03-09       NA  TRUE       <NA>
+      14 AA-AA-000-0000 S17064       <NA>       NA    NA 2012-03-01
+      15 AA-AA-000-0000 S26422       <NA>       NA    NA 2012-02-01
+      16 AA-AA-000-0000 S36886       <NA>       NA    NA 2012-02-01
+      17 AA-AA-000-0000 S38814       <NA>       NA    NA 2012-03-01
+      18 AA-AA-000-0000 S44160       <NA>       NA    NA 2012-02-01
+      19 AA-AA-000-0000 S52428       <NA>       NA    NA 2012-01-01
+      20 AA-AA-000-0000 S58498       <NA>       NA    NA 2012-03-01
+      21 AA-AA-000-0000 S66672       <NA>       NA    NA 2012-02-01
+      22 AA-AA-000-0000 S71069       <NA>       NA    NA 2012-01-01
+      23 AA-AA-000-0000 S75468       <NA>       NA    NA 2012-01-01
+      24 AA-AA-000-0000 S86525       <NA>       NA    NA 2012-02-01
+      25 AA-AA-000-0000 S90150       <NA>       NA    NA 2012-01-01
+      26 AA-AA-000-0000 S90473       <NA>       NA    NA 2012-03-01
+      27 AA-AA-000-0000 S91789       <NA>       NA    NA 2012-03-01
+      28 AA-AA-000-0000 S96425       <NA>       NA    NA 2012-01-01
+

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -42,7 +42,8 @@ lData <- list(
     rename(visit = foldername),
   Raw_Death = lSource$Raw_Death,
   Raw_OverallResponse = lSource$Raw_OverallResponse %>%
-    rename(response_folder = foldername),
+    rename(response_folder = foldername) %>%
+    mutate(pd_date = rs_dt),
   Raw_Randomization = lSource$Raw_Randomization
 )
 

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -39,7 +39,11 @@ lData <- list(
     rename(visit = foldername),
   Raw_IE = lSource$Raw_IE,
   Raw_VISIT = lSource$Raw_VISIT %>%
-    rename(visit = foldername)
+    rename(visit = foldername),
+  Raw_Death = lSource$Raw_DEATH,
+  Raw_OverallResponse = lSource$Raw_OverallResponse %>%
+    rename(response_folder = foldername),
+  Raw_Randomization = lSource$Raw_Randomization
 )
 
 ## Data with missing values (15% NA's)

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -42,8 +42,7 @@ lData <- list(
     rename(visit = foldername),
   Raw_Death = lSource$Raw_Death,
   Raw_OverallResponse = lSource$Raw_OverallResponse %>%
-    rename(response_folder = foldername) %>%
-    mutate(pd_date = rs_dt),
+    rename(response_folder = foldername),
   Raw_Randomization = lSource$Raw_Randomization
 )
 

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -40,7 +40,7 @@ lData <- list(
   Raw_IE = lSource$Raw_IE,
   Raw_VISIT = lSource$Raw_VISIT %>%
     rename(visit = foldername),
-  Raw_Death = lSource$Raw_DEATH,
+  Raw_Death = lSource$Raw_Death,
   Raw_OverallResponse = lSource$Raw_OverallResponse %>%
     rename(response_folder = foldername),
   Raw_Randomization = lSource$Raw_Randomization

--- a/tests/testthat/test-complete_death.R
+++ b/tests/testthat/test-complete_death.R
@@ -1,0 +1,164 @@
+# Data Setup ===================================================================
+test <- mapped_data$Mapped_Death
+
+# Testing ======================================================================
+testthat::test_that("verify complete_death() internal study_comp filter is working properly (#47)", {
+  original_code <- mapped_data$Mapped_STUDCOMP %>%
+    filter(.data$compreas == "Death") %>%
+    full_join(lSource$Raw_Death, by = "subjid") %>%
+    mutate("death" = TRUE)
+
+  double_code <- c(
+    mapped_data$Mapped_STUDCOMP %>%
+      filter(compreas == "Death") %>%
+      pull(subjid),
+    lSource$Raw_Death$subjid
+  ) %>% unique()
+
+  expect_identical(sort(original_code$subjid), sort(double_code))
+})
+
+testthat::test_that("verify complete_death() internal reponse filter is working properly", {
+  original_code <- mapped_data$Mapped_OverallResponse %>%
+    filter(
+      .data$ovrlresp == "PD",
+      !is.na(.data$rs_dt)
+    ) %>%
+    group_by(.data$subjid) %>%
+    slice(which.min(.data$rs_dt)) %>%
+    rename("pd_date" = "rs_dt") %>%
+    ungroup() %>%
+    arrange(subjid)
+
+  double_code <- mapped_data$Mapped_OverallResponse %>%
+    filter(ovrlresp == "PD") %>%
+    group_by(subjid) %>%
+    reframe(first_pd = min(rs_dt)) %>%
+    arrange(subjid)
+
+  expect_identical(original_code$subjid, double_code$subjid)
+  expect_identical(original_code$pd_date, double_code$first_pd)
+})
+
+testthat::test_that("verify complete_death() output is valid for data.frame input (#47)", {
+  expect_snapshot(test)
+  pd <- mapped_data$Mapped_OverallResponse %>%
+    filter(ovrlresp == "PD") %>%
+    group_by(subjid) %>%
+    reframe(first_pd = min(rs_dt))
+
+  study_comp_death <- mapped_data$Mapped_STUDCOMP %>%
+    filter(compreas == "Death") %>%
+    select(subjid, compreas)
+
+  total <- lSource$Raw_Death %>%
+    filter(!is.na(death_dt)) %>%
+    full_join(pd, by = "subjid") %>%
+    full_join(study_comp_death, by = "subjid")
+
+  expect_identical(sort(test$subjid), sort(total$subjid))
+  expect_true(
+    all(
+      c("subjid", "pd_date", "death_dt", "death") %in% names(test)
+    )
+  )
+})
+
+
+test_that("complete_death calculates death_dy correctly", {
+  # Create test data with known dates for verification
+  dfDeath <- data.frame(
+    studyid = c("STUDY001", "STUDY001"),
+    subjid = c("SUBJ001", "SUBJ002"),
+    death_dt = as.Date(c("2023-06-15", "2023-07-20"))
+  )
+
+  dfStudyCompletion <- data.frame(
+    studyid = c("STUDY001", "STUDY001"),
+    subjid = c("SUBJ001", "SUBJ002"),
+    compreas = c("Death", "Death")
+  )
+
+  dfOverallResponse <- data.frame(
+    studyid = c("STUDY001"),
+    subjid = c("SUBJ003"),
+    ovrlresp = c("PD"),
+    rs_dt = as.Date("2023-05-10")
+  )
+
+  dfRandomization <- data.frame(
+    studyid = c("STUDY001", "STUDY001", "STUDY001"),
+    subjid = c("SUBJ001", "SUBJ002", "SUBJ003"),
+    rgmn_dt = as.Date(c("2023-01-01", "2023-02-15", "2023-01-15"))
+  )
+
+  # Run the function
+  result <- complete_death(
+    dfDeath = dfDeath,
+    dfStudyCompletion = dfStudyCompletion,
+    dfOverallResponse = dfOverallResponse,
+    dfRandomization = dfRandomization
+  )
+
+  # Expected death_dy calculations:
+  # SUBJ001: 2023-06-15 - 2023-01-01 = 165 days
+  # SUBJ002: 2023-07-20 - 2023-02-15 = 155 days
+
+  # Test that death_dy is calculated correctly
+  subj001_result <- result[result$subjid == "SUBJ001", ]
+  subj002_result <- result[result$subjid == "SUBJ002", ]
+
+  expect_equal(subj001_result$death_dy, 165)
+  expect_equal(subj002_result$death_dy, 155)
+
+  # Test that death status is set correctly
+  expect_true(subj001_result$death)
+  expect_true(subj002_result$death)
+
+  # Test that death_dt is preserved
+  expect_equal(subj001_result$death_dt, as.Date("2023-06-15"))
+  expect_equal(subj002_result$death_dt, as.Date("2023-07-20"))
+})
+
+test_that("complete_death handles missing randomization dates gracefully", {
+  # Test data with missing randomization date
+  dfDeath <- data.frame(
+    studyid = "STUDY001",
+    subjid = "SUBJ001",
+    death_dt = as.Date("2023-06-15")
+  )
+
+  dfStudyCompletion <- data.frame(
+    studyid = "STUDY001",
+    subjid = "SUBJ001",
+    compreas = "Death"
+  )
+
+  dfOverallResponse <- data.frame(
+    studyid = character(0),
+    subjid = character(0),
+    ovrlresp = character(0),
+    rs_dt = as.Date(character(0))
+  )
+
+  dfRandomization <- data.frame(
+    studyid = "STUDY001",
+    subjid = "SUBJ002",  # Different subject - no match
+    rgmn_dt = as.Date("2023-01-01")
+  )
+
+  # Run the function
+  result <- complete_death(
+    dfDeath = dfDeath,
+    dfStudyCompletion = dfStudyCompletion,
+    dfOverallResponse = dfOverallResponse,
+    dfRandomization = dfRandomization
+  )
+
+  # Test that death_dy is NA when randomization date is missing
+  expect_true(is.na(result$death_dy))
+
+  # Test that other fields are still populated correctly
+  expect_true(result$death)
+  expect_equal(result$death_dt, as.Date("2023-06-15"))
+})

--- a/tests/testthat/test-qual_T1_1.R
+++ b/tests/testthat/test-qual_T1_1.R
@@ -1,5 +1,5 @@
 # Priority 1 mappings
-test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 1 mappings are completed as expected (#97)", {
+test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 1 mappings are completed as expected (#97, #114)", {
   priority1 <- c(
     "AE.yaml",
     "ENROLL.yaml",
@@ -7,7 +7,9 @@ test_that("Qual: mappings now done by individual domain, test that inputs and ou
     "PD.yaml",
     "SDRGCOMP.yaml",
     "STUDCOMP.yaml",
-    "SUBJ.yaml"
+    "SUBJ.yaml",
+    "OverallResponse.yaml",
+    "Randomization.yaml"
   )
 
   mapped_p1_yaml <- map(
@@ -50,8 +52,8 @@ test_that("Qual: mappings now done by individual domain, test that inputs and ou
 
 # Priority 2 Mappings
 
-test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 2 mappings are completed as expected (#97)", {
-  priority2 <- c("DATACHG.yaml", "DATAENT.yaml", "QUERY.yaml")
+test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 2 mappings are completed as expected (#97, #114)", {
+  priority2 <- c("DATACHG.yaml", "DATAENT.yaml", "QUERY.yaml", "Death.yaml")
 
   mapped_p2_yaml <- map(
     priority2,

--- a/tests/testthat/test-qual_T1_1.R
+++ b/tests/testthat/test-qual_T1_1.R
@@ -75,7 +75,7 @@ test_that("Qual: mappings now done by individual domain, test that inputs and ou
   iwalk(
     mapped_p2_yaml,
     ~ expect_true(
-      flatten(.x$steps)$output %in% c(names(mapped_data), "Temp_SubjectLookup", "Raw_Death_Rand")
+      flatten(.x$steps)$output %in% c(names(mapped_data), "Temp_SubjectLookup", "Temp_Death")
     )
   )
 

--- a/tests/testthat/test-qual_T1_1.R
+++ b/tests/testthat/test-qual_T1_1.R
@@ -69,13 +69,13 @@ test_that("Qual: mappings now done by individual domain, test that inputs and ou
 
   iwalk(
     mapped_p2_yaml,
-    ~ expect_true(all(names(.x$spec) %in% c(names(lData), "Mapped_SUBJ")))
+    ~ expect_true(all(names(.x$spec) %in% c(names(lData), "Mapped_SUBJ", "Mapped_Randomization", "Mapped_OverallResponse", "Mapped_STUDCOMP")))
   )
 
   iwalk(
     mapped_p2_yaml,
     ~ expect_true(
-      flatten(.x$steps)$output %in% c(names(mapped_data), "Temp_SubjectLookup")
+      flatten(.x$steps)$output %in% c(names(mapped_data), "Temp_SubjectLookup", "Raw_Death_Rand")
     )
   )
 
@@ -83,7 +83,8 @@ test_that("Qual: mappings now done by individual domain, test that inputs and ou
     mapped_p2_yaml,
     ~ expect_true(all(
       names(flatten(.x$spec)) %in%
-        c(names(lData[names(.x$spec)][[1]]), names(lData["Raw_SUBJ"][[1]]))
+        c(names(lData[names(.x$spec)][[1]]), names(lData["Raw_SUBJ"][[1]]), names(lData["Raw_Randomization"][[1]]),
+          names(lData["Raw_OverallResponse"][[1]]), names(lData["Raw_STUDCOMP"][[1]]))
     ))
   )
 })


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Updates the DEATH mapping workflow to incorporate randomization data and derive a death_days value intended for premature-death KRI calculations (issue https://github.com/Gilead-BioStats/gsm.mapping/issues/114), while also refactoring the prior endpoint-based completion logic into explicit join/query steps.

Changes:

- Add Mapped_Randomization as an input and join it onto Raw_Death.
- Compute a death_days value from rgmn_dt and death_dt in `complete_death()`.
- Migrate the previous gsm.endpoints::complete_death to gsm.mapping::complete_death with tests

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #114 

