### PR TITLE
Link issues to applicable tests and add `qcthat-nocov`

### DIFF
--- a/tests/testthat/test-CalculatePercentage.R
+++ b/tests/testthat/test-CalculatePercentage.R
@@ -1,4 +1,4 @@
-test_that("CalculatePercentage calculates percentage and formats correctly", {
+test_that("CalculatePercentage calculates percentage and formats correctly (#noissue)", {
   # Sample data
   sample_data <- data.frame(
     current = c(50, 20, 30),

--- a/tests/testthat/test-CombineSpecs.R
+++ b/tests/testthat/test-CombineSpecs.R
@@ -1,4 +1,4 @@
-test_that("Combining multiple specs with overlapping dfs, deduplicating cols", {
+test_that("Combining multiple specs with overlapping dfs, deduplicating cols (#2)", {
   spec1 <- list(
     df1 = list(
       col1 = list(type = "character"),
@@ -42,7 +42,7 @@ test_that("Combining multiple specs with overlapping dfs, deduplicating cols", {
   expect_equal(combined, expected)
 })
 
-test_that("Combining specs with non-overlapping dfs", {
+test_that("Combining specs with non-overlapping dfs (#2)", {
   spec1 <- list(
     df1 = list(
       col1 = list(type = "character"),
@@ -73,7 +73,7 @@ test_that("Combining specs with non-overlapping dfs", {
   expect_equal(combined, expected)
 })
 
-test_that("Combining specs with some empty dfs", {
+test_that("Combining specs with some empty dfs (#2)", {
   spec1 <- list(
     df1 = list(),
     df2 = list(
@@ -104,12 +104,12 @@ test_that("Combining specs with some empty dfs", {
   expect_equal(combined, expected)
 })
 
-test_that("Combining empty list of specs returns an empty list", {
+test_that("Combining empty list of specs returns an empty list (#2)", {
   combined <- CombineSpecs(list(), bIsWorkflow = FALSE)
   expect_equal(combined, list())
 })
 
-test_that("Combining a single spec returns the same spec", {
+test_that("Combining a single spec returns the same spec (#2)", {
   spec1 <- list(
     df1 = list(
       col1 = list(type = "character"),
@@ -126,7 +126,7 @@ test_that("Combining a single spec returns the same spec", {
   expect_equal(combined, spec1)
 })
 
-test_that("Combining specs with NULL entries is handled correctly", {
+test_that("Combining specs with NULL entries is handled correctly (#2)", {
   spec1 <- list(
     df1 = list(
       col1 = list(type = "character"),
@@ -154,7 +154,7 @@ test_that("Combining specs with NULL entries is handled correctly", {
   expect_equal(combined, expected)
 })
 
-test_that("warning if type doesn't match first instance", {
+test_that("warning if type doesn't match first instance (#2)", {
   spec1 <- list(
     df1 = list(
       col1 = list(type = "integer")

--- a/tests/testthat/test-Ingest.R
+++ b/tests/testthat/test-Ingest.R
@@ -1,4 +1,4 @@
-test_that("Ingest works with optional columns", {
+test_that("Ingest works with optional columns (#2)", {
   lSourceData <- list(
     df1 = data.frame(
       a = 1:10,

--- a/tests/testthat/test-MakeLongMeta.R
+++ b/tests/testthat/test-MakeLongMeta.R
@@ -1,4 +1,4 @@
-test_that("MakeLongMeta fails for missing columns strGroupCols", {
+test_that("MakeLongMeta fails for missing columns strGroupCols (#noissue)", {
   given <- data.frame(
     GroupID = c(1, 2),
     Param1 = c(10, 20),
@@ -14,7 +14,7 @@ test_that("MakeLongMeta fails for missing columns strGroupCols", {
   )
 })
 
-test_that("MakeLongMeta makes dfGroups", {
+test_that("MakeLongMeta makes dfGroups (#noissue)", {
   given <- data.frame(
     GroupID = c(1, 2),
     Param1 = c(10, 20),


### PR DESCRIPTION
## Overview
This PR updates test names to include linked issue identifiers for qcthat’s Issue–Test Matrix reporting, improving traceability from issues to coverage.

Changes:

- Added `qcthat-nocov` label to applicable closed issues. Please review those even though they are not shown as a part of the PR in 'Files Changed'
- Annotate test_that() descriptions in test-Ingest.R with (#2).
- Annotate multiple test_that() descriptions in test-CombineSpecs.R with (#2).
- Annotate test_that() descriptions in test-MakeLongMeta.R and test-CalculatePercentage.R with (#noissue). There weren't any requirements/issues that would be covered by these tests, because they all were migrated in the PR connected with issues #1 and #2, however the tests didn't seem to cover those issues.

## Connected Issues
- Closes #116 

