### PR TITLE
Update LB.yaml: add rptresn and lbtstnam fields

### DIFF
--- a/inst/workflow/1_mappings/LB.yaml
+++ b/inst/workflow/1_mappings/LB.yaml
@@ -13,6 +13,10 @@ spec:
       type: character
     lb_dt:
       type: Date
+    lbtstnam:
+      type: character
+    rptresn:
+      type: numeric
 steps:
   - output: Mapped_LB
     name: =

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -14,7 +14,11 @@ lData <- list(
     rename(dvdecod = crocategory) %>%
     rename(dvterm = description) %>%
     rename(dvdtm = deviationdate),
-  Raw_LB = lSource$Raw_LB,
+  Raw_LB = lSource$Raw_LB %>%
+    mutate(
+      lbtstnam = "ALT (SGPT)",
+      rptresn = 25
+    ),
   Raw_STUDCOMP = lSource$Raw_STUDCOMP,
   Raw_SDRGCOMP = lSource$Raw_SDRGCOMP %>%
     mutate(phase = as.character(phase)),

--- a/tests/testthat/test-qual_T1_1.R
+++ b/tests/testthat/test-qual_T1_1.R
@@ -1,5 +1,5 @@
 # Priority 1 mappings
-test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 1 mappings are completed as expected (#97, #114, #128)", {
+test_that("Qual: mappings now done by individual domain, test that inputs and outputs of priority 1 mappings are completed as expected (#97, #114, #128, #129)", {
   priority1 <- c(
     "AE.yaml",
     "ENROLL.yaml",


### PR DESCRIPTION
## Summary
Closes #129. Adds `rptresn` (numeric) and `lbtstnam` (character) to the `spec` section of `inst/workflow/1_mappings/LB.yaml`, required to support future lab-based duplicate-record KRI metrics via `Flag_Duplicates()`.

This is a purely additive change; the mapping step remains a direct assignment (`Raw_LB` -> `Mapped_LB`), no transformation logic changes.

## Changes
- `inst/workflow/1_mappings/LB.yaml`: added `lbtstnam` and `rptresn` fields to the `Raw_LB` spec.
- `tests/testthat/helper-qual_data.R`: added `lbtstnam`/`rptresn` values to the `Raw_LB` test fixture directly (via `mutate()`), without relying on updated source data.
- `tests/testthat/test-qual_T1_1.R`: appended `#129` to the priority-1 qualification test's issue tag list (LB.yaml was already covered by the existing `priority1` test).

## Testing
Ran `tests/testthat/test-qual_T1_1.R` locally; all 40 priority-1 expectations pass with the new fields present in `Mapped_LB`.