### PR TITLE
fix: update Gilead-BioStats links to Gilead-Public

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the `gsm` suite of packages!
 
-This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).  
+This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).  
 Please review those guidelines before opening issues or submitting pull requests.
 
 ## Key Points
@@ -12,4 +12,4 @@ Please review those guidelines before opening issues or submitting pull requests
 - Track your issue on the [`gsm` Roadmap Project Board](https://github.com/orgs/Gilead-BioStats/projects/41).  
 - All code changes should be made in a branch and submitted as a PR following the guidelines linked above.  
   
-For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).
+For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,7 +8,7 @@
 ## Milestone
 <!--- Link to the milestone for the release. ---> 
 <!--- Make sure all relevant issues/PRs are included on the linked pages. --->
-Milestone: [v1.0.0](https://github.com/Gilead-BioStats/gsm.mapping/milestone/1)
+Milestone: [v1.0.0](https://github.com/Gilead-Public/gsm.mapping/milestone/1)
 
 # Overall Risk Assessment 
 <!--- Complete the following Risk Assessment for this Release-->
@@ -45,6 +45,6 @@ Notes:
 - [ ] Formatted code with `styler`
 - [ ] Run `spell_check()`
 - [ ] Completed QC of documentation including `README.md` and relevant Vignettes
-- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-biostats.github.io/gsm.mapping/reference/index.html)" page. 
+- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-public.github.io/gsm.mapping/reference/index.html)" page. 
 - [ ] Draft GitHub release created using automatic template and updated with additional details. Remember to click "release" after PR is merged.  
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,9 @@ Description: The Good Statistical Monitoring or 'gsm' R package provides a
     workflows to apply the necessary data transformation from raw/source
     datasets to appropriate domains.
 License: Apache License (>= 2)
-URL: https://github.com/Gilead-BioStats/gsm.mapping,
-    https://gilead-biostats.github.io/gsm.mapping
-BugReports: https://github.com/Gilead-BioStats/gsm.mapping/issues
+URL: https://github.com/Gilead-Public/gsm.mapping,
+    https://gilead-public.github.io/gsm.mapping
+BugReports: https://github.com/Gilead-Public/gsm.mapping/issues
 Depends: 
     R (>= 4.0)
 Imports:
@@ -42,8 +42,8 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@dev,
-    workr=Gilead-BioStats/workr@main
+    gsm.core=Gilead-Public/gsm.core@dev,
+    workr=Gilead-Public/workr@main
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.mapping/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.mapping/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -29,7 +29,7 @@ The {gsm} ecosystem provides a standardized Risk Based Quality Monitoring (RBQM)
 </center>
 
 The `{gsm.mapping}` package provides the necessary functions and workflows to perform the data transformation from raw/source datasets to appropriate domains.
-This README provides a high-level overview of {gsm.mapping}; see the [package website](https://gilead-biostats.github.io/gsm.mapping/) for additional details.
+This README provides a high-level overview of {gsm.mapping}; see the [package website](https://gilead-public.github.io/gsm.mapping/) for additional details.
 
 ## Installation
 
@@ -37,7 +37,7 @@ You can install the latest release of gsm.mapping from [GitHub](https://github.c
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.mapping@*release")
+pak::pak("Gilead-Public/gsm.mapping@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -47,7 +47,7 @@ You can install the development version of gsm.mapping from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.mapping")
+pak::pak("Gilead-Public/gsm.mapping")
 ```
 
 </div>
@@ -57,7 +57,7 @@ Clinical trial data often presents challenges due to its complexity and variabil
 
 When integrating data from the Clinical Trial Management System (CTMS), it is often necessary to consolidate and transform data from various folders and sources into appropriate "domains." During the reporting process, while SDTM standards are commonly applied to ensure compliance, they may not always align with the specific requirements of RBQM. The goal of `{gsm.mapping}` is to provide a flexible framework for mapping data into domains tailored to support risk assessments during trial monitoring.
 
-There is no single standardized format for raw or mapped data within `{gsm.mapping}`. The only requirement is that mapped data must be compatible with the analytics pipeline. Data transformations can be implemented using various methods, including custom R scripts (e.g., with dplyr), SQL queries, or pre-defined gsm workflows. Pre-defined workflows can be found in this package in the `workflow` directory, or as examples in the [gsm Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html#mappings).
+There is no single standardized format for raw or mapped data within `{gsm.mapping}`. The only requirement is that mapped data must be compatible with the analytics pipeline. Data transformations can be implemented using various methods, including custom R scripts (e.g., with dplyr), SQL queries, or pre-defined gsm workflows. Pre-defined workflows can be found in this package in the `workflow` directory, or as examples in the [gsm Extensions vignette](https://gilead-public.github.io/gsm.core/articles/gsmExtensions.html#mappings).
 
 # Process Overview
 The workflow for a particular mapped domain requires the following sections:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.mapping
+url: https://gilead-public.github.io/gsm.mapping
 template:
   bootstrap: 5
   bootswatch: yeti

--- a/man/gsm.mapping-package.Rd
+++ b/man/gsm.mapping-package.Rd
@@ -11,9 +11,9 @@ The Good Statistical Monitoring or 'gsm' R package provides a framework for stat
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/Gilead-BioStats/gsm.mapping}
-  \item \url{https://gilead-biostats.github.io/gsm.mapping}
-  \item Report bugs at \url{https://github.com/Gilead-BioStats/gsm.mapping/issues}
+  \item \url{https://github.com/Gilead-Public/gsm.mapping}
+  \item \url{https://gilead-public.github.io/gsm.mapping}
+  \item Report bugs at \url{https://github.com/Gilead-Public/gsm.mapping/issues}
 }
 
 }
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Jeremy Wildfire \email{jwildfire@gmail.com}
   \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}
   \item Zelos Zhu \email{zelos.zhu@atorusresearch.com}
 }

--- a/pkgdown/menus/examples/Example_MappingWorkflow.Rmd
+++ b/pkgdown/menus/examples/Example_MappingWorkflow.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Example Mapping Workflow"
-author: "[gsm.mapping](https://gilead-biostats.github.io/gsm.mapping) Example"
+author: "[gsm.mapping](https://gilead-public.github.io/gsm.mapping) Example"
 description: "Example of creating the Mapped Data Layer step-by-step using the standard mappings in gsm.mapping"
 index: 1
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/vignettes/add_new_domain_var.Rmd
+++ b/vignettes/add_new_domain_var.Rmd
@@ -16,9 +16,9 @@ This guide provides detailed instructions for users on how to submit requests fo
 
 ### 1. **Navigate to the GitHub Issues Page**
 
-a.  Visit the repository's GitHub [page](https://github.com/Gilead-BioStats/gsm.mapping).
+a.  Visit the repository's GitHub [page](https://github.com/Gilead-Public/gsm.mapping).
 b.  Click on the **Issues** tab located at the top of the repository page and click the green **New Issue** button.
-c.  Or click [here](https://github.com/Gilead-BioStats/gsm.mapping/issues/new/choose)
+c.  Or click [here](https://github.com/Gilead-Public/gsm.mapping/issues/new/choose)
 
 ### 2. **Open a New Issue**
 


### PR DESCRIPTION
## Summary
Updates all direct `Gilead-BioStats` org links to `Gilead-Public` across docs, config, and metadata files.

## Changes
- Replaced `github.com/Gilead-BioStats` → `github.com/Gilead-Public` in all applicable files.
- Replaced `gilead-biostats.github.io` → `gilead-public.github.io` in all applicable files.

## Intentional non-updated links
- `NEWS.md` PR links (lines 40, 43, 60, 64, 68, 72, 76) — historical changelog entries pointing to old org PRs.
- `orgs/Gilead-BioStats/projects/41` in `.github/CONTRIBUTING.md` and issue templates — org-level project board.

## Validation
- `grep -rn "Gilead-BioStats\|gilead-biostats.github.io" --exclude-dir=man .` returns only the intentional keeps listed above.

Closes #154